### PR TITLE
Update homepage title text

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <h1>Welcome to Eurostar CI/CD Demo</h1>
+  <h1>Welcome to Eurostar CI/CD</h1>
   <p>This static site is deployed automatically using GitHub Actions.</p>
 </body>
 </html>


### PR DESCRIPTION
Removed 'Demo' from the main heading to reflect the finalized Eurostar CI/CD site.